### PR TITLE
feat: stop when no next slide

### DIFF
--- a/flowery/__init__.py
+++ b/flowery/__init__.py
@@ -23,6 +23,7 @@ class Presentation:
 
     def next(self):
         if self.index >= self.__len__() - 1:
+            self.stop()
             return
         self.index = self.index + 1
         self.update()


### PR DESCRIPTION
With this modification, when calling `next()` when there is no next slide, the
presentation ends.