### PR TITLE
feat: split slides on thematic lines

### DIFF
--- a/flowery/__init__.py
+++ b/flowery/__init__.py
@@ -8,7 +8,8 @@ from rich.layout import Layout
 
 class Presentation:
     def __init__(self, content):
-        self.slides = [slide_content for slide_content in content.split("\n# ")]
+        self.slides = [slide_content.strip() for slide_content in content.split("---\n")]
+        print(self.slides)
         for i in range(1, len(self.slides)):
             self.slides[i] = "# " + self.slides[i]
         self.index = 0

--- a/tests/functionnal/test_play_slides.py
+++ b/tests/functionnal/test_play_slides.py
@@ -8,11 +8,15 @@ EXAMPLE_PRESENTATION = """# Slide 1
 
 This is the content of the slide
 
+---
+
 # Slide 2
 
 ```sh
 ls *
 ```
+
+---
 
 # Slide 3
 

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -5,20 +5,31 @@ from unittest.mock import patch
 
 from flowery import Presentation
 
+ONE_SLIDE="# Slide"
+TWO_SLIDES="""# Slide 1
+---
+# Slide 2
+"""
+
+THREE_HEADINGS_NO_LINES="""# Slide 1
+# Slide 2
+# Slide 3"""
+
+ONE_HEADING_THREE_LINES="""---
+# Slide
+---
+Some text"""
 
 class TestPresentation(unittest.TestCase):
     def test_can_be_instantiated(self):
-        Presentation("""# Slide""")
+        Presentation(ONE_SLIDE)
 
     def test_fail_if_empty(self):
         with self.assertRaises(TypeError):
             Presentation()
 
     def test_2_slides_if_2_titles(self):
-        presentation = Presentation(
-            """# Slide 1
-# Slide 2"""
-        )
+        presentation = Presentation(TWO_SLIDES)
         self.assertEqual(len(presentation), 2)
 
     def test_1_slide_if_no_title(self):
@@ -36,10 +47,7 @@ class TestPresentation(unittest.TestCase):
 
     @patch.object(Presentation, "update")
     def test_next_slide_shown_on_next(self, update):
-        presentation = Presentation(
-            """# Slide 1
-# Slide 2"""
-        )
+        presentation = Presentation(TWO_SLIDES)
         presentation.start()
         update.reset_mock()
 
@@ -47,3 +55,7 @@ class TestPresentation(unittest.TestCase):
 
         update.assert_called()
         presentation.stop()
+
+    def test_break_on_thematic_lines(self):
+        self.assertEqual(len(Presentation(THREE_HEADINGS_NO_LINES)), 1)
+        self.assertEqual(len(Presentation(ONE_HEADING_THREE_LINES)), 3)


### PR DESCRIPTION
To allow more control for the user, the slides are splitted using thematic
lines:

```md

First slide

---

Second slide

```